### PR TITLE
Fix_recherche_trombi

### DIFF
--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -52,7 +52,7 @@ class UserController extends AbstractController
                 $request->query->getInt('page', 1),
                 self::USERS_PER_PAGE,
                 ['pageOutOfRange' => 'fix']
-            );   
+            );
         }
 
         return $this->render('trombinoscope/index.html.twig', [

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -39,15 +39,21 @@ class UserController extends AbstractController
         if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             $ambassadors = $userRepository->findBySearch($data['search']);
+            $users = $paginator->paginate(
+                $ambassadors,
+                $request->query->getInt('page', 1),
+                self::USERS_PER_PAGE,
+                ['pageOutOfRange' => 'fix']
+            );
         } else {
             $ambassadors = $userRepository->findAll();
+            $users = $paginator->paginate(
+                $ambassadors,
+                $request->query->getInt('page', 1),
+                self::USERS_PER_PAGE,
+                ['pageOutOfRange' => 'fix']
+            );
         }
-
-        $users = $paginator->paginate(
-            $ambassadors,
-            $request->query->getInt('page', 1),
-            self::USERS_PER_PAGE
-        );
 
         return $this->render('trombinoscope/index.html.twig', [
             'form' => $form->createView(),

--- a/src/Form/SearchingType.php
+++ b/src/Form/SearchingType.php
@@ -21,7 +21,6 @@ class SearchingType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'method' => 'get',
             'csrf_protection' => false
         ]);
     }

--- a/src/Form/SearchingType.php
+++ b/src/Form/SearchingType.php
@@ -4,6 +4,7 @@ namespace App\Form;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\Extension\Core\Type\SearchType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class SearchingType extends AbstractType
 {
@@ -12,6 +13,21 @@ class SearchingType extends AbstractType
         $builder
             ->add('search', SearchType::class, [
                 'required' => false,
-            ]);
+            ])
+            ->setMethod('GET')
+            ->getForm();
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'method' => 'get',
+            'csrf_protection' => false
+        ]);
+    }
+
+    public function getBlockPrefix()
+    {
+        return '';
     }
 }


### PR DESCRIPTION
suppression du token csrf et de [Search] dans l'URL
Permet la recherche de cards du trombi avec pagination